### PR TITLE
Add IMPORT, use symlinks, and use default build commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ This Action allows you to run Go commands with your code. It will automatically 
 ## How to use
 
 1. Add an Action
-2. Enter "cedrickring/golang-action@1.0.0"
-3. Add a command in the args section like:
+2. Enter "cedrickring/golang-action@1.1.0"
+3. If your repo builds with `make` or `go build && go test`, that's all you need.  Otherwise, add a command in the args section like:
     ```bash
     go build -o my_executable main.go
     ```
@@ -14,3 +14,25 @@ This Action allows you to run Go commands with your code. It will automatically 
     ```bash
     make test
     ```
+
+If your repository's `import` name is different from the path on GitHub,
+provide the `import` name by adding an environment variable
+`IMPORT=import/name`.  This may be useful if you have forked an open
+source Go project.
+
+If you prefer editing your `main.workflow` files by hand, use an `action`
+block like this:
+
+```hcl
+action "ci" {
+  uses="cedrickring/golang-action@1.1.0"
+
+  # optional build command:
+  args="./build.sh"
+
+  # optional import name:
+  env={
+    IMPORT="root/repo"
+  }
+}
+```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,8 +10,8 @@ WORKDIR="${GOPATH}/src/github.com/${IMPORT}"
 # Go can only find dependencies if they're under $GOPATH/src.
 # GitHub Actions mounts your repository outside of $GOPATH.
 # So symlink the repository into $GOPATH, and then cd to it.
-mkdir -p `dirname ${WORKDIR}`
-ln -s ${PWD} ${WORKDIR}
-cd ${WORKDIR}
+mkdir -p "`dirname "${WORKDIR}"`"
+ln -s "${PWD}" "${WORKDIR}"
+cd "${WORKDIR}"
 
 sh -c "$*"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,4 +14,15 @@ mkdir -p "`dirname "${WORKDIR}"`"
 ln -s "${PWD}" "${WORKDIR}"
 cd "${WORKDIR}"
 
-sh -c "$*"
+# If a command was specified with `args="..."`, then run it.  Otherwise,
+# look for something useful to run.
+if [ $# -eq 0 ]; then
+  if [ -r Makefile ]; then
+    make
+  else
+    go build ./...
+    go test ./...
+  fi
+else
+  sh -c "$*"
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,11 +6,12 @@ if [ -z "${IMPORT}" ]; then
   IMPORT="${GITHUB_REPOSITORY}"
 fi
 WORKDIR="${GOPATH}/src/github.com/${IMPORT}"
-# create go work dir
-mkdir -p ${WORKDIR}
-# copy all files from workspace to work dir
-cp -R /github/workspace/* ${WORKDIR}
-# cd into the work dir and run all commands from there
+
+# Go can only find dependencies if they're under $GOPATH/src.
+# GitHub Actions mounts your repository outside of $GOPATH.
+# So symlink the repository into $GOPATH, and then cd to it.
+mkdir -p `dirname ${WORKDIR}`
+ln -s ${PWD} ${WORKDIR}
 cd ${WORKDIR}
 
 sh -c "$*"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@ set -e
 if [ -z "${IMPORT}" ]; then
   IMPORT="${GITHUB_REPOSITORY}"
 fi
-WORKDIR="/go/src/github.com/${IMPORT}"
+WORKDIR="${GOPATH}/src/github.com/${IMPORT}"
 # create go work dir
 mkdir -p ${WORKDIR}
 # copy all files from workspace to work dir

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,11 @@
 #!/bin/sh
 
-set -eu
+set -e
 
-WORKDIR="/go/src/github.com/${GITHUB_REPOSITORY}"
+if [ -z "${IMPORT}" ]; then
+  IMPORT="${GITHUB_REPOSITORY}"
+fi
+WORKDIR="/go/src/github.com/${IMPORT}"
 # create go work dir
 mkdir -p ${WORKDIR}
 # copy all files from workspace to work dir


### PR DESCRIPTION
This PR adds three features to the `entrypoint.sh` script.

 - It allows `env={IMPORT="root/repo"}` for cases where a repository's `import` name isn't the same as its repo name on GitHub, as is often the case when you fork a golang project.
 - It uses `ln -s` instead of `cp -R`, to save time and space when building large repos.
 - It provides `make` (if there's a Makefile) or `go build && go test` as default commands.  In many cases the user won't have to specify `args`.

So the simplest usage is now:
```hcl
action "ci" {
  uses="cedrickring/golang-action@1.1.0"
}
```

I've made each of the three additions its own commit(s), in case you want to cherry-pick and choose.