### PR TITLE
Add build/test/publish actions for golang-action

### DIFF
--- a/.dockerfile_lint/default_rules.yaml
+++ b/.dockerfile_lint/default_rules.yaml
@@ -1,0 +1,173 @@
+# https://github.com/projectatomic/dockerfile_lint
+---
+  profile:
+    name: "Default"
+    description: "Default Profile. Checks basic syntax."
+  line_rules:
+    LABEL:
+       paramSyntaxRegex: /.+/
+       defined_namevals:
+           Name:
+             valueRegex: /[\w]+/
+             message: "Label 'name' is missing or has invalid format"
+             level: "error"
+             required: true
+           Version:
+             valueRegex: /[\w.${}()"'\\\/~<>\-?\%:]+/
+             message: "Label 'version' is missing or has invalid format"
+             level: "error"
+             required: true
+           Maintainer:
+             valueRegex: /[\w]+/
+             message: "Label 'maintainer' is missing or has invalid format"
+             level: "error"
+             required: true
+
+    FROM: 
+      paramSyntaxRegex: /^[\w./\-:]+(:[\w.]+)?(-[\w]+)?( as \w+)?$/i
+      rules: 
+        - 
+          label: "is_latest_tag"
+          regex: /latest/
+          level: "error"
+          message: "base image uses 'latest' tag"
+          description: "using the 'latest' tag may cause unpredictable builds. It is recommended that a specific tag is used in the FROM line or *-released which is the latest supported release."
+          reference_url: 
+            - "https://docs.docker.com/engine/reference/builder/"
+            - "#from"
+        - 
+          label: "no_tag"
+          regex: /^[:]/
+          level: "error"
+          message: "No tag is used"
+          description: "lorem ipsum tar"
+          reference_url: 
+            - "https://docs.docker.com/engine/reference/builder/"
+            - "#from"
+    RUN:
+      paramSyntaxRegex: /.+/
+      rules: 
+        - 
+          label: "no_yum_clean_all"
+          regex: /yum(?!.+clean all|.+\.repo|-config|\.conf)/g
+          level: "warn"
+          message: "yum clean all is not used"
+          description: "the yum cache will remain in this layer making the layer unnecessarily large"
+          reference_url: 
+            - "http://docs.projectatomic.io/container-best-practices/#"
+            - "_clear_packaging_caches_and_temporary_package_downloads"
+        - 
+          label: "yum_update_all"
+          regex: /yum(.+update all|.+upgrade|.+update|\.config)/
+          level: "info"
+          message: "updating the entire base image may add unnecessary size to the container"
+          description: "update the entire base image may add unnecessary size to the container"
+          reference_url: 
+            - "http://docs.projectatomic.io/container-best-practices/#"
+            - "_clear_packaging_caches_and_temporary_package_downloads"
+        -
+          label: "no_dnf_clean_all"
+          regex: /dnf(?!.+clean all|.+\.repo)/g
+          level: "warn"
+          message: "dnf clean all is not used"
+          description: "the dnf cache will remain in this layer making the layer unnecessarily large"
+          reference_url: 
+            - "http://docs.projectatomic.io/container-best-practices/#"
+            - "_clear_packaging_caches_and_temporary_package_downloads"
+        -
+          label: "no_rvm_cleanup_all"
+          regex: /rvm install(?!.+cleanup all)/g
+          level: "warn"
+          message: "rvm cleanup is not used"
+          description: "the rvm cache will remain in this layer making the layer unnecessarily large"
+          reference_url: 
+            - "http://docs.projectatomic.io/container-best-practices/#"
+            - "_clear_packaging_caches_and_temporary_package_downloads"
+        -
+          label: "no_gem_clean_all"
+          regex: /gem install(?!.+cleanup|.+\rvm cleanup all)/g
+          level: "warn"
+          message: "gem cleanup all is not used"
+          description: "the gem cache will remain in this layer making the layer unnecessarily large"
+          reference_url: 
+            - "http://docs.projectatomic.io/container-best-practices/#"
+            - "_clear_packaging_caches_and_temporary_package_downloads" 
+        -
+          label: "no_apt-get_clean"
+          regex: /apt-get install(?!.+clean)/g
+          level: "warn"
+          message: "apt-get clean is not used"
+          description: "the apt-get cache will remain in this layer making the layer unnecessarily large"
+          reference_url: 
+            - "http://docs.projectatomic.io/container-best-practices/#"
+            - "_clear_packaging_caches_and_temporary_package_downloads" 
+        -
+          label: "privileged_run_container"
+          regex: /privileged/
+          level: "warn"
+          message: "a privileged run container is allowed access to host devices"
+          description: "Does this run need to be privileged?"
+          reference_url: 
+            - "http://docs.docker.com/engine/reference/run/#"
+            - "runtime-privilege-and-linux-capabilities"
+        -
+          label: "installing_ssh"
+          regex: /openssh-server/
+          level: "warn"
+          message: "installing SSH in a container is not recommended"
+          description: "Do you really need SSH in this image?"
+          reference_url: "https://github.com/jpetazzo/nsenter"	
+        - 
+          label: "no_ampersand_usage"
+          regex: / ; /
+          level: "warn"
+          message: "using ; instead of &&"
+          description: "RUN do_1 && do_2: The ampersands change the resulting evaluation into do_1 and then do_2 only if do_1 was successful."
+          reference_url:
+            - "http://docs.projectatomic.io/container-best-practices/#"
+            - "#_using_semi_colons_vs_double_ampersands"
+    EXPOSE: 
+      paramSyntaxRegex: /^[\d-\s\w/\\]+$/
+      rules: []
+    ENV:
+      paramSyntaxRegex: /.+/
+      rules: []
+    ADD: 
+      paramSyntaxRegex: /^~?([\w-.~:/?#\[\]\\\/*@!$&'()*+,;=.{}"]+[\s]*)+$/
+    COPY: 
+      paramSyntaxRegex: /.+/
+      rules: []
+    ENTRYPOINT: 
+      paramSyntaxRegex: /.+/
+      rules: []
+    VOLUME:
+      paramSyntaxRegex: /.+/
+      rules: []
+    USER: 
+      paramSyntaxRegex: /^[a-z0-9_][a-z0-9_]{0,40}$/
+      rules: []
+    WORKDIR: 
+      paramSyntaxRegex: /^~?[\w\d-\/.{}$\/:]+[\s]*$/
+      rules: []
+    ONBUILD: 
+      paramSyntaxRegex: /.+/
+      rules: []
+  required_instructions:
+    -
+      instruction: "ENTRYPOINT"
+      count: 1
+      level: "info"
+      message: "There is no 'ENTRYPOINT' instruction"
+      description: "None"
+      reference_url:
+        - "https://docs.docker.com/engine/reference/builder/"
+        - "#entrypoint"
+    -
+      instruction: "CMD"
+      count: 1
+      level: "info"
+      message: "There is no 'CMD' instruction"
+      description: "None"
+      reference_url:
+        - "https://docs.docker.com/engine/reference/builder/"
+        - "#cmd"

--- a/.dockerfile_lint/github_actions.yaml
+++ b/.dockerfile_lint/github_actions.yaml
@@ -1,0 +1,138 @@
+# https://github.com/projectatomic/dockerfile_lint
+profile:
+  name: "GitHub Actions"
+  description: "Checks for GitHub Actions."
+  includes:
+    - default_rules.yaml
+general:
+  # It appears these get duplicated rather than overriding.  The hope was to use this as a counter to the
+  # `required_instructions` section, but perhaps it defines the `line_rules` map.  It would be great to either be able
+  # to set `required_instructions` to a 0 value or have an `invalid_instructions` section?
+  valid_instructions:
+    - FROM
+    - RUN
+    - CMD
+    - LABEL
+    - ENV
+    - ADD
+    - COPY
+    - ENTRYPOINT
+    - WORKDIR
+    - ONBUILD
+    - ARG
+    - STOPSIGNAL
+    - SHELL
+line_rules:
+  # Invalid Lines
+  ADD:
+    paramSyntaxRegex: /.+/
+    rules:
+    -
+      label: "add_antipattern"
+      regex: /.+/
+      level: "info"
+      message: "Avoid using ADD"
+      description: "It is generally an anti-pattern to us ADD, use COPY instead."
+  EXPOSE:
+    paramSyntaxRegex: /.+/
+    rules:
+    -
+      label: "expose_invalid"
+      regex: /.+/
+      level: "error"
+      message: "There should not be an 'EXPOSE' instruction"
+      description: "Actions should not expose ports."
+  HEALTHCHECK:
+    paramSyntaxRegex: /.+/
+    rules:
+    -
+      label: "healthcheck_invalid"
+      regex: /.+/
+      level: "error"
+      message: "There should not be a 'HEALTHCHECK' instruction"
+      description: "Actions should not require HEALTHCHECKs."
+  MAINTAINER:
+    paramSyntaxRegex: /.+/
+    rules:
+      -
+        label: "maintainer_deprecated"
+        regex: /.+/
+        level: "info"
+        message: "the MAINTAINER command is deprecated"
+        description: "MAINTAINER is deprecated in favor of using LABEL since Docker v1.13.0"
+        reference_url:
+          - "https://github.com/docker/cli/blob/master/docs/deprecated.md"
+          - "#maintainer-in-dockerfile"
+  SHELL:
+    paramSyntaxRegex: /.+/
+    rules:
+    -
+      label: "shell_invalid"
+      regex: /.+/
+      level: "info"
+      message: "There should not be a 'SHELL' instruction"
+      description: "Actions generally rely on sh and setting an alternative shell may have unexpected consequences."
+  USER:
+    paramSyntaxRegex: /.+/
+    rules:
+    -
+      label: "user_discouraged"
+      regex: /.+/
+      level: "warn"
+      message: "'USER' instruction exists"
+      description: "Actions don't expect a USER to be set."
+  VOLUME:
+    paramSyntaxRegex: /.+/
+    rules:
+    -
+      label: "volume_invalid"
+      regex: /.+/
+      level: "error"
+      message: "There should not be a 'VOLUME' instruction"
+      description: "Actions do not support volumes."
+
+  # Required Labels
+  LABEL:
+    paramSyntaxRegex: /.+/
+    defined_namevals:
+      com.github.actions.name:
+        valueRegex: /[\w]+/
+        message: "Label 'com.github.actions.name' is missing or has invalid format"
+        level: "error"
+        required: true
+      com.github.actions.description:
+        valueRegex: /[\w]+/
+        message: "Label 'com.github.actions.description' is missing or has invalid format"
+        level: "error"
+        required: true
+      com.github.actions.icon:
+        valueRegex: /[\w]+/
+        message: "Label 'com.github.actions.icon' is missing or has invalid format"
+        level: "error"
+        required: true
+      com.github.actions.color:
+        valueRegex: /[\w]+/
+        message: "Label 'com.github.actions.color' is missing or has invalid format"
+        level: "error"
+        required: true
+
+
+required_instructions:
+  -
+    instruction: "ENTRYPOINT"
+    count: 1
+    level: "error"
+    message: "There is no 'ENTRYPOINT' instruction"
+    description: "Actions require that a default ENTRYPOINT be set"
+    reference_url:
+    - "https://docs.docker.com/engine/reference/builder/"
+    - "#entrypoint"
+  -
+    instruction: "CMD"
+    count: 1
+    level: "info"
+    message: "There is no 'CMD' instruction"
+    description: "In most cases it is helpful to include reasonable defaults for CMD"
+    reference_url:
+    - "https://docs.docker.com/engine/reference/builder/"
+    - "#cmd"

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,0 +1,46 @@
+workflow "Build and Publish" {
+  on = "push"
+  resolves = "Docker Publish"
+}
+
+action "Lint" {
+  uses = "actions/action-builder/shell@master"
+  runs = "make"
+  args = "lint"
+}
+
+action "Test" {
+  uses = "actions/action-builder/shell@master"
+  runs = "make"
+  args = "test"
+}
+
+action "Build" {
+  needs = ["Lint", "Test"]
+  uses = "actions/docker/cli@master"
+  args = "build -t golang-action ."
+}
+
+action "Publish Filter" {
+  needs = ["Build"]
+  uses = "actions/bin/filter@master"
+  args = "branch master"
+}
+
+action "Docker Login" {
+  needs = ["Publish Filter"]
+  uses = "actions/docker/login@master"
+  secrets = ["DOCKER_USERNAME", "DOCKER_PASSWORD"]
+}
+
+action "Docker Publish" {
+  needs = ["Publish Filter", "Build", "Docker Login", "Docker Tag"]
+  uses = "actions/docker/cli@master"
+  args = "push cedrickring/golang-action"
+}
+
+action "Docker Tag" {
+  needs = ["Build", "Docker Login"]
+  uses = "actions/docker/tag@master"
+  args = "golang-action cedrickring/golang-action --no-latest"
+}

--- a/.github/publish.workflow
+++ b/.github/publish.workflow
@@ -1,31 +1,8 @@
-workflow "Build on Push" {
-  on = "push"
-  resolves = "Build"
-}
 
 workflow "Build and Publish" {
   on = "release"
   resolves = "Docker Publish"
 }
-
-action "Lint" {
-  uses = "actions/action-builder/shell@master"
-  runs = "make"
-  args = "lint"
-}
-
-action "Test" {
-  uses = "actions/action-builder/shell@master"
-  runs = "make"
-  args = "test"
-}
-
-action "Build" {
-  needs = ["Lint", "Test"]
-  uses = "actions/docker/cli@master"
-  args = "build -t golang-action ."
-}
-
 
 action "Docker Login" {
   uses = "actions/docker/login@master"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
 FROM golang:1.11
 
+LABEL name="Golang Action"
+LABEL maintainer="Cedric Kring"
 LABEL version="1.1.0"
 LABEL repository="https://github.com/cedrickring/golang-action"
-LABEL maintainer="Cedric Kring"
 
 LABEL com.github.actions.name="Golang Action"
 LABEL com.github.actions.description="Run Golang commands"
 LABEL com.github.actions.icon="box"
 LABEL com.github.actions.color="blue"
 
-ADD entrypoint.sh /entrypoint.sh
+COPY entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+.DEFAULT_GOAL := default
+
+include docker.mk
+include shell.mk
+
+.PHONY: clean
+clean: ## Clean up after the build process.
+
+.PHONY: lint
+lint: shell-lint docker-lint ## Lint all of the files for this Action.
+
+.PHONY: build
+build: docker-build ## Build this Action.
+
+.PHONY: test
+test: shell-test  ## Test the components of this Action.
+
+.PHONY: publish
+publish: docker-publish ## Publish this Action.
+
+.PHONY: default
+default: lint build test
+
+include help.mk

--- a/docker.mk
+++ b/docker.mk
@@ -1,0 +1,19 @@
+IMAGE_NAME=$(shell basename $(CURDIR))
+DOCKER_REPO?="cedrickring"
+ROOT_DIR?=$(CURDIR)
+
+.PHONY: docker-lint
+docker-lint: ## Run Dockerfile Lint on all dockerfiles.
+	dockerfile_lint -r $(ROOT_DIR)/.dockerfile_lint/github_actions.yaml $(wildcard Dockerfile* */Dockerfile*)
+
+.PHONY: docker-build
+docker-build: ## Build the top level Dockerfile using the directory or $IMAGE_NAME as the name.
+	docker build -t $(IMAGE_NAME) .
+
+.PHONY: docker-tag
+docker-tag: ## Tag the docker image using the tag script.
+	docker tag $(IMAGE_NAME) $(DOCKER_REPO)/$(IMAGE_NAME)
+
+.PHONY: docker-publish
+docker-publish: docker-tag ## Publish the image and tags to a repository.
+	docker push $(DOCKER_REPO)/$(IMAGE_NAME)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ WORKDIR="${GOPATH}/src/github.com/${IMPORT}"
 # Go can only find dependencies if they're under $GOPATH/src.
 # GitHub Actions mounts your repository outside of $GOPATH.
 # So symlink the repository into $GOPATH, and then cd to it.
-mkdir -p "`dirname "${WORKDIR}"`"
+mkdir -p "$(dirname "${WORKDIR}")"
 ln -s "${PWD}" "${WORKDIR}"
 cd "${WORKDIR}"
 

--- a/help.mk
+++ b/help.mk
@@ -1,0 +1,3 @@
+.PHONY: help
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | sed 's/^[^:]*://g' | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/shell.mk
+++ b/shell.mk
@@ -1,0 +1,10 @@
+SHELL_FILES=$(wildcard *.sh */*.sh)
+BATS_TESTS=$(wildcard *.bats */*.bats)
+
+.PHONY: shell-lint
+shell-lint:
+	shellcheck $(SHELL_FILES)
+
+.PHONY: shell-test
+shell-test:
+	test $(BATS_TEST) && bats $(BATS_TESTS) || exit 0


### PR DESCRIPTION
Adds in a Github actions workflow to:
- Run Tests/Lint - run docker_lint and (in the future any bats shell test to test `entrpoint.sh`)
  - As recommended by the official github actions https://github.com/actions/action-builder
     - https://github.com/actions/action-builder/blob/master/single-action.workflow
- Build - builds the golang-action `Dockerfile` `missing name LABEL`
- Added some fixes to conform to `docker_lint` and `shellcheck` `don't use backticks instead use $()`


I was able to test and run it locally using:
- https://github.com/nektos/act
```
$ go get -u github.com/nektos/act
$ act -l 
act -l
  

  ╔═════════════╗
  ║ EVENT: push ║
  ╚═════════════╝
        ⬇
 ╭──────╮ ╭──────╮
 │ Lint │ │ Test │
 ╰──────╯ ╰──────╯
        ⬇
     ╭───────╮
     │ Build │
     ╰───────╯


         ╔════════════════╗
         ║ EVENT: release ║
         ╚════════════════╝
                 ⬇
 ╭──────╮ ╭──────╮ ╭──────────────╮
 │ Lint │ │ Test │ │ Docker Login │
 ╰──────╯ ╰──────╯ ╰──────────────╯
                 ⬇
             ╭───────╮
             │ Build │
             ╰───────╯
                 ⬇
           ╭────────────╮
           │ Docker Tag │
           ╰────────────╯
                 ⬇
         ╭────────────────╮
         │ Docker Publish │
         ╰────────────────╯


```

Running locally it runs all the steps and stops at Publish (because its not running from `@master`
```
$ act
[Test] git clone 'https://github.com/actions/action-builder' # ref=master
[Lint] git clone 'https://github.com/actions/action-builder' # ref=master
[Test] docker build -t action-builder:master /var/folders/tv/d5hn3rbs2p776ybs3g92_00w0000gr/T/act/actions/action-builder/shell@master/shell
[Test] docker run image=action-builder:master entrypoint=["make"] cmd=["test"]
[Lint] docker build -t action-builder:master /var/folders/tv/d5hn3rbs2p776ybs3g92_00w0000gr/T/act/actions/action-builder/shell@master/shell
[Lint] docker run image=action-builder:master entrypoint=["make"] cmd=["lint"]
test  && bats  || exit 0
shellcheck entrypoint.sh
dockerfile_lint -r /github/workspace/.dockerfile_lint/github_actions.yaml Dockerfile

# Analyzing Dockerfile


--------INFO---------

INFO: There is no 'CMD' instruction. In most cases it is helpful to include reasonable defaults for CMD.
Reference -> https://docs.docker.com/engine/reference/builder/#cmd


[Build] git clone 'https://github.com/actions/docker' # ref=master
[Build] docker build -t docker:master /var/folders/tv/d5hn3rbs2p776ybs3g92_00w0000gr/T/act/actions/docker/cli@master/cli
[Build] docker run image=docker:master entrypoint=[] cmd=["build" "-t" "golang-action" "."]
Sending build context to Docker daemon  234.5kB
Step 1/11 : FROM golang:1.11
 ---> 901414995ecd
Step 2/11 : LABEL name="Golang Action"
 ---> Using cache
 ---> 2f9e261416ee
Step 3/11 : LABEL maintainer="Cedric Kring"
 ---> Using cache
 ---> c9db4f214467
Step 4/11 : LABEL version="1.1.0"
 ---> Using cache
 ---> 7aad81ee87c5
Step 5/11 : LABEL repository="https://github.com/cedrickring/golang-action"
 ---> Using cache
 ---> 32b835786c11
Step 6/11 : LABEL com.github.actions.name="Golang Action"
 ---> Using cache
 ---> 5dd6d449b474
Step 7/11 : LABEL com.github.actions.description="Run Golang commands"
 ---> Using cache
 ---> 5aafadd36c66
Step 8/11 : LABEL com.github.actions.icon="box"
 ---> Using cache
 ---> 482e77276a8f
Step 9/11 : LABEL com.github.actions.color="blue"
 ---> Using cache
 ---> 60c1df74031d
Step 10/11 : COPY entrypoint.sh /entrypoint.sh
 ---> Using cache
 ---> c666dae6f42c
Step 11/11 : ENTRYPOINT ["/entrypoint.sh"]
 ---> Using cache
 ---> de4a9694e3c7
Successfully built de4a9694e3c7
Successfully tagged golang-action:latest
[Publish Filter] git clone 'https://github.com/actions/bin' # ref=master
[Publish Filter] docker build -t bin:master /var/folders/tv/d5hn3rbs2p776ybs3g92_00w0000gr/T/act/actions/bin/filter@master/filter
[Publish Filter] docker run image=bin:master entrypoint=[] cmd=["branch" "master"]
refs/heads/action-lint does not match refs/heads/master
Error: exit with `NEUTRAL`: 78
```

I also added a Publishing flow that will tag and publish the golang-action to Docker hub when commits are pushed to `@master`.

It will tag using the version in the actions `Dockerfile`:
For example:
- https://hub.docker.com/r/dougnukem/golang-action/tags
```
# Dockerfile Github Action Version: 1.1.0
golang-action:1.1.0
# Major version
golang-action:1
# Commit hash
golang-action:a467e57 
# Branch ref
golang-action:action-lint
```

**NOTE**
- This requires configuring Github action env variable secrets to login to https://hub.docker.com/r/cedrickring/ docker hub repo 
   - `DOCKER_USERNAME`, `DOCKER_PASSWORD`


