### PR TITLE
Add README.MD badges for github action build status and latest release version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![](https://img.shields.io/github/release/cedrickring/golang-action.svg)](https://github.com/cedrickring/golang-action/releases/latest) [![Actions Status](https://wdp9fww0r9.execute-api.us-west-2.amazonaws.com/production/badge/cedrickring/golang-action)](https://github.com/cedrickring/golang-action/commits/master)
 # Golang Action
 
 This Action allows you to run Go commands with your code. It will automatically setup your workspace (`~/go/src/github.com/<your-name>/<repo>`) before the command is run.
@@ -5,7 +6,7 @@ This Action allows you to run Go commands with your code. It will automatically 
 ## How to use
 
 1. Add an Action
-2. Enter "cedrickring/golang-action@1.1.1" (`cedrickring/golang-action/go1.10@1.1.1` for Golang 1.10, 1.11, 1.12) 
+2. Enter "cedrickring/golang-action@1.1.1" (`cedrickring/golang-action/go1.10@1.1.1` for Golang 1.10, 1.11, 1.12)
 3. If your repo builds with `make` or `go build && go test`, that's all you need.  Otherwise, add a command in the args section like:
     ```bash
     go build -o my_executable main.go


### PR DESCRIPTION
Adds readme badges for:

- Github action build status: [![Actions Status](https://wdp9fww0r9.execute-api.us-west-2.amazonaws.com/production/badge/cedrickring/golang-action)](https://github.com/cedrickring/golang-action/commits/master)
- Latest release version: [![](https://img.shields.io/github/release/cedrickring/golang-action.svg)](https://github.com/cedrickring/golang-action/releases/latest)