### PR TITLE
Workaround for #8  failing in Action tests

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -10,7 +10,8 @@ action "Lint" {
 }
 
 action "Test" {
-  needs = ["Build", "Test Go Standard", "Test Go Modules", "Test Go Modules Vendor", "Test Go Dep", "Test Go Dep Vendor"]
+  # TODO: Add back "Test Go Dep Vendor" once we resolve issue with `dep check` reporting invalid hash: https://github.com/cedrickring/golang-action/issues/8
+  needs = ["Build", "Test Go Standard", "Test Go Modules", "Test Go Modules Vendor", "Test Go Dep"]
   uses = "actions/action-builder/shell@master"
   runs = "make"
   args = "test"


### PR DESCRIPTION
Temporary workaround for #8 until we can figure out why `dep check` fails on vendored go project.

It might only be an issue with the specific `/x/text` package, or some inconsistency with macOS where the tests were created and Linux where the test runs on github action, but we should remove this as a failure of `master` for now and enable support for `dep vendored` separately 