### PR TITLE
Closes #8 Fixes action test failure for go dep with vendored dependencies

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,8 +38,14 @@ if [ $# -eq 0 ] || [ "$*" = "" ]; then
       if [ -r Gopkg.toml ]; then
         # Check if using vendored dependencies
         if [ -d "vendor" ]; then
-          # Check that dep is in sync with /vendor dependencies
-          "$GOPATH/bin/dep" check
+          # Check that dep is in sync with /vendor dependencies and that running dep ensure doesn't result in modifications to Gopkg.lock/Gopkg.toml
+          "$GOPATH/bin/dep" ensure && "$GOPATH/bin/dep" check
+          git_workspace_status="$(git status --porcelain)"
+          if [ -n "${git_workspace_status}" ]; then
+            echo "Unexpected changes were found in dep /vendored. Please run $(dep ensure) and commit changes:";
+            echo "${git_workspace_status}";
+            exit 1;
+          fi
         else
           # Run dep ensure to download and sync dependencies
           "$GOPATH/bin/dep" ensure

--- a/go1.10/entrypoint.sh
+++ b/go1.10/entrypoint.sh
@@ -38,8 +38,14 @@ if [ $# -eq 0 ] || [ "$*" = "" ]; then
       if [ -r Gopkg.toml ]; then
         # Check if using vendored dependencies
         if [ -d "vendor" ]; then
-          # Check that dep is in sync with /vendor dependencies
-          "$GOPATH/bin/dep" check
+          # Check that dep is in sync with /vendor dependencies and that running dep ensure doesn't result in modifications to Gopkg.lock/Gopkg.toml
+          "$GOPATH/bin/dep" ensure && "$GOPATH/bin/dep" check
+          git_workspace_status="$(git status --porcelain)"
+          if [ -n "${git_workspace_status}" ]; then
+            echo "Unexpected changes were found in dep /vendored. Please run $(dep ensure) and commit changes:";
+            echo "${git_workspace_status}";
+            exit 1;
+          fi
         else
           # Run dep ensure to download and sync dependencies
           "$GOPATH/bin/dep" ensure

--- a/go1.11/entrypoint.sh
+++ b/go1.11/entrypoint.sh
@@ -38,8 +38,14 @@ if [ $# -eq 0 ] || [ "$*" = "" ]; then
       if [ -r Gopkg.toml ]; then
         # Check if using vendored dependencies
         if [ -d "vendor" ]; then
-          # Check that dep is in sync with /vendor dependencies
-          "$GOPATH/bin/dep" check
+          # Check that dep is in sync with /vendor dependencies and that running dep ensure doesn't result in modifications to Gopkg.lock/Gopkg.toml
+          "$GOPATH/bin/dep" ensure && "$GOPATH/bin/dep" check
+          git_workspace_status="$(git status --porcelain)"
+          if [ -n "${git_workspace_status}" ]; then
+            echo "Unexpected changes were found in dep /vendored. Please run $(dep ensure) and commit changes:";
+            echo "${git_workspace_status}";
+            exit 1;
+          fi
         else
           # Run dep ensure to download and sync dependencies
           "$GOPATH/bin/dep" ensure

--- a/go1.12/entrypoint.sh
+++ b/go1.12/entrypoint.sh
@@ -38,8 +38,14 @@ if [ $# -eq 0 ] || [ "$*" = "" ]; then
       if [ -r Gopkg.toml ]; then
         # Check if using vendored dependencies
         if [ -d "vendor" ]; then
-          # Check that dep is in sync with /vendor dependencies
-          "$GOPATH/bin/dep" check
+          # Check that dep is in sync with /vendor dependencies and that running dep ensure doesn't result in modifications to Gopkg.lock/Gopkg.toml
+          "$GOPATH/bin/dep" ensure && "$GOPATH/bin/dep" check
+          git_workspace_status="$(git status --porcelain)"
+          if [ -n "${git_workspace_status}" ]; then
+            echo "Unexpected changes were found in dep /vendored. Please run $(dep ensure) and commit changes:";
+            echo "${git_workspace_status}";
+            exit 1;
+          fi
         else
           # Run dep ensure to download and sync dependencies
           "$GOPATH/bin/dep" ensure


### PR DESCRIPTION
Closes #8, Closes #2  - fixes github action run failure on the test case of a go project with dep vendored dependencies.

Now instead of just running `dep check` we will run `dep ensure && dep check` and check that nothing in the git workspace is modified/untracked e.g. `Gopkg.toml/Gopkg.lock` which would indicate there are changes to dependencies that were not explicitly committed.