### PR TITLE
Use GITHUB_REPOSITORY environment variable if present

### DIFF
--- a/docker.mk
+++ b/docker.mk
@@ -1,6 +1,6 @@
 IMAGE_NAME?=golang-action
-GITHUB_REPO=$(shell git remote get-url origin | sed 's/.*\/\(.*\)\/\(.*\)\.git/\1\/\2/')
-DOCKER_REPO=$(shell echo $(GITHUB_REPO) | sed 's/\(.*\)\/\(.*\)/\1/')
+GITHUB_REPOSITORY?=$(shell git remote get-url origin | sed 's/.*\/\(.*\)\/\(.*\)\.git/\1\/\2/')
+DOCKER_REPOSITORY=$(shell echo $(GITHUB_REPOSITORY) | sed 's/\(.*\)\/\(.*\)/\1/')
 ROOT_DIR?=$(CURDIR)
 GO_VERSION_DIRS=$(wildcard go*)
 GO_VERSIONS=$(shell echo $(GO_VERSION_DIRS) | sed 's/go//g')
@@ -23,18 +23,18 @@ docker-build: update-docker-go-versions ## Build the top level Dockerfile using 
 	
 .PHONY: docker-tag
 docker-tag: ## Tag the docker image using the tag script.
-	docker tag $(IMAGE_NAME):latest $(DOCKER_REPO)/$(IMAGE_NAME):$(ACTION_VERSION)
-	docker tag $(IMAGE_NAME):latest $(DOCKER_REPO)/$(IMAGE_NAME):$(ACTION_MAJOR_VERSION)
-	docker tag $(IMAGE_NAME):latest $(DOCKER_REPO)/$(IMAGE_NAME):$(ACTION_MAJOR_VERSION).$(ACTION_MINOR_VERSION)
+	docker tag $(IMAGE_NAME):latest $(DOCKER_REPOSITORY)/$(IMAGE_NAME):$(ACTION_VERSION)
+	docker tag $(IMAGE_NAME):latest $(DOCKER_REPOSITORY)/$(IMAGE_NAME):$(ACTION_MAJOR_VERSION)
+	docker tag $(IMAGE_NAME):latest $(DOCKER_REPOSITORY)/$(IMAGE_NAME):$(ACTION_MAJOR_VERSION).$(ACTION_MINOR_VERSION)
 	for version in $(GO_VERSIONS) ; do \
-		docker tag $(IMAGE_NAME):$$version $(DOCKER_REPO)/$(IMAGE_NAME):$(ACTION_VERSION)-go$$version; \
-		docker tag $(IMAGE_NAME):$$version $(DOCKER_REPO)/$(IMAGE_NAME):$(ACTION_MAJOR_VERSION)-go$$version; \
-		docker tag $(IMAGE_NAME):$$version $(DOCKER_REPO)/$(IMAGE_NAME):$(ACTION_MAJOR_VERSION).$(ACTION_MINOR_VERSION)-go$$version; \
+		docker tag $(IMAGE_NAME):$$version $(DOCKER_REPOSITORY)/$(IMAGE_NAME):$(ACTION_VERSION)-go$$version; \
+		docker tag $(IMAGE_NAME):$$version $(DOCKER_REPOSITORY)/$(IMAGE_NAME):$(ACTION_MAJOR_VERSION)-go$$version; \
+		docker tag $(IMAGE_NAME):$$version $(DOCKER_REPOSITORY)/$(IMAGE_NAME):$(ACTION_MAJOR_VERSION).$(ACTION_MINOR_VERSION)-go$$version; \
 	done
 
 .PHONY: docker-publish
 docker-publish: docker-tag ## Publish the image and tags to a repository.
-	docker push $(DOCKER_REPO)/$(IMAGE_NAME)
+	docker push $(DOCKER_REPOSITORY)/$(IMAGE_NAME)
 	
 .PHONY: update-docker-go-versions
 update-docker-go-versions: ## Updates go go1.10, go1.11 from the main Dockerfile


### PR DESCRIPTION
@dougnukem the release workflow currently fails due to the missing `git` executable. I changed the `docker.mk` to use the `GITHUB_REPOSITORY` variable if present (changed the docker repo variable too for consistency).

See [here](https://github.com/cedrickring/golang-action/runs/82062572)