### PR TITLE
Defaults to Go 1.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11
+FROM golang:1.12
 
 LABEL name="Golang Action"
 LABEL maintainer="Cedric Kring"


### PR DESCRIPTION
Currently, `golang-action` will use Go 1.11 if no version of Go is specified. According to the documentation, not specifying a version should default to the latest version of Go, which is 1.12.