### PR TITLE
Fix README.md's usage of job instead of jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Create a `workflow.yaml` file in `.github/workflows` with the following contents
 ```yaml
 on: push
 name: My cool Action
-job:
+jobs:
   checks:
     name: run
     runs-on: ubuntu-latest


### PR DESCRIPTION
The workflow yaml file should have a `jobs` list, not a `job` list.  This is preventing the example workflow from triggering if used as-is.