### PR TITLE
Add specific permissions to workflows under .github/workflows

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,6 +22,8 @@ jobs:
         IMPORT: cedrickring/golang-action
         PROJECT_PATH: ./tests/projects/go_standard
   action-checks:
+    permissions:
+      contents: read
     name: Run action checks
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -25,6 +25,8 @@ jobs:
         IMPORT: cedrickring/golang-action
         PROJECT_PATH: ./tests/projects/go_standard
   test:
+    permissions:
+      contents: read
     name: Run tests and build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ on: release
 name: Publish to Docker Hub
 jobs:
   publish:
+    permissions:
+      contents: read
     name: Publish docker images
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR adds specific permissions to the existing workflows under .github/workflows.

### Background

I am the founder of [Step Security](https://www.stepsecurity.io), and have implemented a [GitHub App](https://github.com/apps/step-security) to automatically restrict permissions for the GITHUB_TOKEN in workflows. This is a security best practice as per the GitHub Actions [hardening guide](https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions). 

I am trying the App out on public repositories, by forking them, installing the App on the fork, and manually creating PRs with the fixed workflows. The App automatically fixes permissions when a new PR is created that changes  a workflow, so feel free to install it on your repo for future workflows, or try it out on other repos. 

I have manually reviewed the changes, and they do look good to me. If something looks off, please let me know. If you have feedback, would love to hear it. Unfortunately, permissions for some jobs could not be fixed, since it uses your action as a local action (./) which is not supported as of now. Thanks!